### PR TITLE
Update StructLayoutAttribute.xml

### DIFF
--- a/xml/System.Runtime.InteropServices/StructLayoutAttribute.xml
+++ b/xml/System.Runtime.InteropServices/StructLayoutAttribute.xml
@@ -262,7 +262,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The <xref:System.Runtime.InteropServices.StructLayoutAttribute.Pack> field controls the alignment of a type's fields in memory.  It affects both <xref:System.Runtime.InteropServices.LayoutKind.Sequential?displayProperty=nameWithType> and <xref:System.Runtime.InteropServices.LayoutKind.Explicit?displayProperty=nameWithType>. By default, the value is 0, indicating the default packing size for the current platform. The value of <xref:System.Runtime.InteropServices.StructLayoutAttribute.Pack> must be 0, 1, 2, 4, 8, 16, 32, 64, or 128:  
+ The <xref:System.Runtime.InteropServices.StructLayoutAttribute.Pack> field controls the alignment of a type's fields in memory.  It affects <xref:System.Runtime.InteropServices.LayoutKind.Sequential?displayProperty=nameWithType>. By default, the value is 0, indicating the default packing size for the current platform. The value of <xref:System.Runtime.InteropServices.StructLayoutAttribute.Pack> must be 0, 1, 2, 4, 8, 16, 32, 64, or 128:  
   
  The fields of a type instance are aligned by using the following rules:  
   


### PR DESCRIPTION
Fix remark about what `LayoutKind`s `StructLayoutAttribute.Pack` affects (only `Sequential`)

## Summary

Removed mention of `StructLayoutAttribute.Pack` affecting `LayoutKind.Explicit`.

Fixes #5318
<!-- If the issue is found in <https://github.com/dotnet/docs, this takes the form "Fixes dotnet/docs#Issue_Number" -->

